### PR TITLE
Handle missing github token for metrics

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Minimal permissions for metrics generation
+      metadata: read
+      actions: read
     steps:
       - uses: lowlighter/metrics@latest
         with:


### PR DESCRIPTION
Add `metadata: read` and `actions: read` permissions to the metrics workflow to allow the `lowlighter/metrics` action to gather all necessary data.

---
<a href="https://cursor.com/background-agent?bcId=bc-da84a861-a7aa-4676-9ad9-5e8d31eb6590">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da84a861-a7aa-4676-9ad9-5e8d31eb6590">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>