### PR TITLE
Update yaml for language pie chart

### DIFF
--- a/.github/workflows/language-stats.yml
+++ b/.github/workflows/language-stats.yml
@@ -27,4 +27,5 @@ jobs:
           plugin_languages_recent_load: 300
           plugin_languages_sections: most-used
           plugin_languages_threshold: 0%
+          plugin_languages_details: pie-chart
           config_timezone: Asia/Kathmandu

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.METRICS_TOKEN }}
           user: niranjannlc
           template: classic
-          base: header, activity, community, repositories, metadata
+          base: header
           plugin_languages: yes
           plugin_languages_analysis_timeout: 15
           plugin_languages_categories: markup, programming
@@ -27,10 +27,5 @@ jobs:
           plugin_languages_recent_load: 300
           plugin_languages_sections: most-used
           plugin_languages_threshold: 0%
-          plugin_activity: yes
-          plugin_activity_days: 14
-          plugin_activity_filter: all
-          plugin_activity_limit: 5
-          plugin_activity_load: 300
-          plugin_activity_visibility: all
+          plugin_languages_details: pie-chart
           config_timezone: Asia/Kathmandu


### PR DESCRIPTION
Configure GitHub metrics to display language usage as a pie chart and remove detailed activity metrics.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c4f376e-aa9c-4bbf-b1e0-30624353fcbf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c4f376e-aa9c-4bbf-b1e0-30624353fcbf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>