### PR TITLE
Fix pie chart display issue

### DIFF
--- a/.github/workflows/language-stats.yml
+++ b/.github/workflows/language-stats.yml
@@ -28,4 +28,5 @@ jobs:
           plugin_languages_sections: most-used
           plugin_languages_threshold: 0%
           plugin_languages_details: pie-chart
+          plugin_languages_indepth: no
           config_timezone: Asia/Kathmandu

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -28,4 +28,5 @@ jobs:
           plugin_languages_sections: most-used
           plugin_languages_threshold: 0%
           plugin_languages_details: pie-chart
+          plugin_languages_indepth: no
           config_timezone: Asia/Kathmandu


### PR DESCRIPTION
Add `plugin_languages_indepth: no` to language metrics configuration to attempt to fix pie chart rendering.

The `lowlighter/metrics` plugin was generating horizontal bar charts instead of pie charts even when `plugin_languages_details: pie-chart` was set. This change adds `plugin_languages_indepth: no` as a potential fix for this rendering issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-85208c87-52db-4384-aa2a-7d8391fbd823">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85208c87-52db-4384-aa2a-7d8391fbd823">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>